### PR TITLE
Fix bug in cryptfs_verify_passwd with hardware disk encryption

### DIFF
--- a/cryptfs.c
+++ b/cryptfs.c
@@ -2450,16 +2450,6 @@ int cryptfs_verify_passwd(char *passwd)
         return -2;
     }
 
-    if (!master_key_saved) {
-        SLOGE("encrypted fs not yet mounted, aborting");
-        return -1;
-    }
-
-    if (!saved_mount_point) {
-        SLOGE("encrypted fs failed to save mount point, aborting");
-        return -1;
-    }
-
     if (get_crypt_ftr_and_key(&crypt_ftr)) {
         SLOGE("Error getting crypt footer and key\n");
         return -1;
@@ -2476,6 +2466,17 @@ int cryptfs_verify_passwd(char *passwd)
             else
               rc = -1;
         } else {
+#endif
+            if (!master_key_saved) {
+                SLOGE("encrypted fs not yet mounted, aborting");
+                return -1;
+            }
+
+            if (!saved_mount_point) {
+                SLOGE("encrypted fs failed to save mount point, aborting");
+                return -1;
+            }
+
             decrypt_master_key(passwd, decrypted_master_key, &crypt_ftr, 0, 0);
             if (!memcmp(decrypted_master_key, saved_master_key, crypt_ftr.keysize)) {
                 /* They match, the password is correct */
@@ -2485,16 +2486,7 @@ int cryptfs_verify_passwd(char *passwd)
                 sleep(1);
                 rc = 1;
             }
-        }
-#else
-        decrypt_master_key(passwd, decrypted_master_key, &crypt_ftr, 0, 0);
-        if (!memcmp(decrypted_master_key, saved_master_key, crypt_ftr.keysize)) {
-            /* They match, the password is correct */
-            rc = 0;
-        } else {
-            /* If incorrect, sleep for a bit to prevent dictionary attacks */
-            sleep(1);
-            rc = 1;
+#ifdef CONFIG_HW_DISK_ENCRYPTION
         }
 #endif
     }


### PR DESCRIPTION
When using hardware based disk encryption, there will not be a
saved_master_key or saved_mount_point. However, cryptfs_verify_passwd
checks these things before going into the hardware encryption flow,
which causes it to always fail.

In this change, we restructure hardware encryption flow control and move
some ifdefs around, so that checking saved_master_key and
saved_mount_point will only happen when using software encryption.

Change-Id: I0e45c0bcfabaa44e28751c0e8dcc41dad1030a2c